### PR TITLE
Fix idle-change checks.

### DIFF
--- a/flycheck-nim.el
+++ b/flycheck-nim.el
@@ -91,9 +91,9 @@ See http://nim-lang.org"
             (eval (--map (format "--warning[%s]:%s" (car it) (cadr it))
                          flycheck-nim-specific-warnings))
             (eval flycheck-nim-args)
-            ;; Must use source-original so relative imports and
+            ;; Must use source-inplace so relative imports and
             ;; qualified references to local variables resolve correctly
-            source-original)
+            source-inplace)
   :error-patterns
   ((error line-start (file-name) "(" line ", "
           column ") Error:"


### PR DESCRIPTION
Using "source-original" as the file to be checked breaks idle syntax checking by Flycheck.
By using "source-inplace" instead, that works and so do relative imports.
