### PR TITLE
Disable checker in org mode source blocks

### DIFF
--- a/flycheck-nim.el
+++ b/flycheck-nim.el
@@ -106,7 +106,8 @@ See http://nim-lang.org"
   :error-filter
   (lambda (errors)
     (flycheck-sanitize-errors (flycheck-increment-error-columns errors)))
-  :modes (nim-mode nimrod-mode))
+  :modes (nim-mode nimrod-mode)
+  :predicate (lambda () (not org-src-mode)))
 
 (add-to-list 'flycheck-checkers 'nim)
 


### PR DESCRIPTION
Add predicate to avoid running the checker inside org mode source blocks.
https://github.com/Lompik/ob-nim adds support for evaluating org-mode source code blocks but the temporary buffer and files it creates causes flycheck-nim to always return an error making it annoying and useless in this context.